### PR TITLE
Change of visibility for InternalBody of region entity

### DIFF
--- a/Piranha/Entities/Region.cs
+++ b/Piranha/Entities/Region.cs
@@ -59,6 +59,11 @@ namespace Piranha.Entities
 				SetBody(value) ;
 			}
 		}
+
+        /// <summary>
+        /// Gets/sets the private Json serialized body.
+        /// </summary>
+        public string InternalBody { get; set; }
 		#endregion
 
 		#region Navigation properties
@@ -72,14 +77,7 @@ namespace Piranha.Entities
 		/// </summary>
 		public RegionTemplate RegionTemplate { get ; set ; }
 		#endregion
-
-		#region Internal properties
-		/// <summary>
-		/// Gets/sets the private Json serialized body.
-		/// </summary>
-		internal string InternalBody { get ; set ; }
-		#endregion
-
+        
 		/// <summary>
 		/// Gets the typed body element.
 		/// </summary>


### PR DESCRIPTION
Changed the visibility for InternalBody from internal to public to allow LINQ queries to be performed on the serialized region body. This is referenced in issue #365 .