### PR TITLE
Changed visibility for InternalBody of Region entity

### DIFF
--- a/Piranha/Entities/Region.cs
+++ b/Piranha/Entities/Region.cs
@@ -59,6 +59,11 @@ namespace Piranha.Entities
 				SetBody(value) ;
 			}
 		}
+
+        /// <summary>
+        /// Gets/sets the private Json serialized body.
+        /// </summary>
+        public string InternalBody { get; set; }
 		#endregion
 
 		#region Navigation properties
@@ -71,13 +76,6 @@ namespace Piranha.Entities
 		/// Gets/sets the region template.
 		/// </summary>
 		public RegionTemplate RegionTemplate { get ; set ; }
-		#endregion
-
-		#region Internal properties
-		/// <summary>
-		/// Gets/sets the private Json serialized body.
-		/// </summary>
-		internal string InternalBody { get ; set ; }
 		#endregion
 
 		/// <summary>


### PR DESCRIPTION
Moved InternalBody from Internal Properties to Properties and changed access modifier from internal to public. This maked it possible to run LINQ queries on the serialized body, e.g. for searching in content. This was referenced in issue #365 and after creating a pull request for branch 2.2.4 ( #366 ) a pull request for branch 2.2.5 was requested instead.