### PR TITLE
entitySchema config option (2.2.5)

### DIFF
--- a/Piranha/Config.cs
+++ b/Piranha/Config.cs
@@ -57,6 +57,17 @@ namespace Piranha
 			}
 		}
 
+        /// <summary>
+        /// Gets an optional default schema for Entity Framework.
+        /// </summary>
+        public static string EntitySchema
+        {
+            get
+            {
+                return config.Settings.EntitySchema.Value;
+            }
+        }
+
 		/// <summary>
 		/// Gets/sets if the page & post type builder of the Extension Manager
 		/// should be disabled.

--- a/Piranha/ConfigFile.cs
+++ b/Piranha/ConfigFile.cs
@@ -55,6 +55,7 @@ namespace Piranha
 		private const string PASSIVE_MODE = "passiveMode";
 		private const string PREFIXLESS_PERMALINKS = "prefixlessPermalinks";
 		private const string RENDERX_UA_COMPATIBLEFORIE = "renderX-UA-CompatibleForIE";
+        private const string ENTITY_SCHEMA = "entitySchema";
 		#endregion
 
 		/// <summary>
@@ -83,6 +84,16 @@ namespace Piranha
 			get { return (BooleanElement)this[DISABLE_MANAGER]; }
 			set { this[DISABLE_MANAGER] = value; }
 		}
+
+        /// <summary>
+        /// Gets/sets an optional default schema for Entity Framework.
+        /// </summary>
+        [ConfigurationProperty(ENTITY_SCHEMA, IsRequired = false)]
+        public StringElement EntitySchema
+        {
+            get { return (StringElement)this[ENTITY_SCHEMA]; }
+            set { this[ENTITY_SCHEMA] = value; }
+        }
 
 		/// <summary>
 		/// Gets/sets if the page & post type builder of the Extension Manager

--- a/Piranha/DataContext.cs
+++ b/Piranha/DataContext.cs
@@ -7,6 +7,7 @@ using System.Data.Entity.Validation;
 using System.Data.Entity.Core.Objects;
 using System.Linq;
 using System.Text;
+using System.Data.Entity.ModelConfiguration.Conventions;
 
 namespace Piranha
 {
@@ -110,7 +111,7 @@ namespace Piranha
 		/// </summary>
 		/// <param name="modelBuilder">The model builder</param>
 		protected override void OnModelCreating(DbModelBuilder modelBuilder) {
-			modelBuilder.Configurations.Add(new Entities.Maps.UserMap()) ;
+            modelBuilder.Configurations.Add(new Entities.Maps.UserMap()) ;
 			modelBuilder.Configurations.Add(new Entities.Maps.GroupMap()) ;
 			modelBuilder.Configurations.Add(new Entities.Maps.PermissionMap()) ;
 			modelBuilder.Configurations.Add(new Entities.Maps.ParamMap()) ;
@@ -130,6 +131,11 @@ namespace Piranha
 			modelBuilder.Configurations.Add(new Entities.Maps.ExtensionMap()) ;
 			modelBuilder.Configurations.Add(new Entities.Maps.UploadMap()) ;
 			modelBuilder.Configurations.Add(new Entities.Maps.CommentMap()) ;
+
+            if (!string.IsNullOrWhiteSpace(Config.EntitySchema))
+            {
+                modelBuilder.HasDefaultSchema(Config.EntitySchema);
+            }
 
 			base.OnModelCreating(modelBuilder);
 		}


### PR DESCRIPTION
Added config option 'entitySchema' to allow EF to use custom schema. (Migrated pull request from 2.2.4 to 2.2.5)