### PR TITLE
Fixes #371

### DIFF
--- a/Piranha/Web/Handlers/PermalinkHandler.cs
+++ b/Piranha/Web/Handlers/PermalinkHandler.cs
@@ -47,10 +47,13 @@ namespace Piranha.Web.Handlers
 						segments = 0;
 						// Accept permalinks with '/' in them
 						for (int n = 0; n < args.Length; n++) {
-							perm = Permalink.GetByName(Config.DefaultNamespaceId, args.Subset(0, args.Length - n).Implode("/")) ;
+							Permalink post = Permalink.GetByName(Config.DefaultNamespaceId, args.Subset(0, args.Length - n).Implode("/"));
 							segments = args.Length - n;
-							if (perm != null && perm.Type == Permalink.PermalinkType.POST)
-								break ;
+							if (post != null && post.Type == Permalink.PermalinkType.POST)
+							{
+								perm = post;
+								break;
+							}
 						}
 					}
 


### PR DESCRIPTION
Changed logic when checking for a post in the default site. If the
returned Permalink is a Post, then the it is returned, otherwise perm
will remain null and therefore return a 404.