### PR TITLE
Use current protocol in preview URL #423

### DIFF
--- a/Core/Piranha/WebPages/WebPiranha.cs
+++ b/Core/Piranha/WebPages/WebPiranha.cs
@@ -171,7 +171,8 @@ namespace Piranha.WebPages
 		/// <returns>The url</returns>
 		public static string GetSiteUrl() {
 			var context = HttpContext.Current;
-			var url = "http://" + context.Request.Url.DnsSafeHost +
+		    var protocol = context.Request.IsSecureConnection ? "https://" : "http://";
+			var url = protocol + context.Request.Url.DnsSafeHost +
 				(!context.Request.Url.IsDefaultPort ? ":" + context.Request.Url.Port : "") +
 				context.Request.ApplicationPath;
 


### PR DESCRIPTION
Fixed Preview URL's doesn't take protocol into account #423, now it uses
current protocol.