### PR TITLE
Update Page.cs - Keywords character limit

### DIFF
--- a/Core/Piranha/Entities/Internal/Page.cs
+++ b/Core/Piranha/Entities/Internal/Page.cs
@@ -141,7 +141,7 @@ namespace Piranha.Models
 		/// </summary>
 		[Column(Name = "page_keywords")]
 		[Display(ResourceType = typeof(Piranha.Resources.Page), Name = "Keywords")]
-		[StringLength(255, ErrorMessageResourceType = typeof(Piranha.Resources.Page), ErrorMessageResourceName = "KeywordsLength")]
+		[StringLength(128, ErrorMessageResourceType = typeof(Piranha.Resources.Page), ErrorMessageResourceName = "KeywordsLength")]
 		public string Keywords { get; set; }
 
 		/// <summary>


### PR DESCRIPTION
The Database limits a Page's Keywords to nvarchar(128) but this limitation is not reflected in the Page class. The Resources (Page.resx) message will also need to be updated to reflect the 128 limit.