### PR TITLE
Hide overflow with ellipsis for 'type' on site map

### DIFF
--- a/Core/Piranha/Areas/Manager/Content/Css/style.css
+++ b/Core/Piranha/Areas/Manager/Content/Css/style.css
@@ -1279,6 +1279,9 @@ ul.sitemap .date {
 }
 ul.sitemap .type {
   width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 ul.sitemap .title {
   float: none;


### PR DESCRIPTION
Prevent layout breaking when the value is long enough to cause line wrap